### PR TITLE
init die selection

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,11 @@
             "top":      "ToP"
         },
 
+        "dialog": {
+            "initTitle":    "Choose an Initiative Die",
+            "initBody":     "Please select the appropriate initiative die."
+        },
+
         "atk":  "atk",
         "def":  "def",
         "dmg":  "dmg",

--- a/modules/actor/actor.js
+++ b/modules/actor/actor.js
@@ -161,6 +161,5 @@ export class HackmasterActor extends Actor {
             }, {});
             return res;
         }
-
     }
 }

--- a/modules/hackmaster.js
+++ b/modules/hackmaster.js
@@ -44,7 +44,7 @@ Hooks.once("ready", async() => {
     //    game.items.contents[0].sheet.render(true);
     }
     if (game.actors.contents[0]) {
-        game.actors.contents[0].sheet.render(true);
+//        game.actors.contents[0].sheet.render(true);
     }
 
     LOGGER.log("Ready complete.");

--- a/modules/sys/combat.js
+++ b/modules/sys/combat.js
@@ -33,6 +33,44 @@ export class HMCombat extends Combat {
          if ( cn !== 0 ) return cn;
          return a.id - b.id;
     }
+
+    async rollAll(options={}) {
+        const ids = this.combatants.reduce((ids, c) => {
+            if ( c.isOwner && !c.initiative) ids.push(c.id);
+            return ids;
+        }, []);
+        const initDie = await this._getInitiativeDie();
+        const initFormula = initDie;
+        options.formula = initFormula;
+        return this.rollInitiative(ids, options);
+    }
+
+    async rollNPC(options={}) {
+        const ids = this.combatants.reduce((ids, c) => {
+        if ( c.isOwner && c.isNPC && !c.initiative) ids.push(c.id);
+            return ids;
+        }, []);
+        const initDie = await this._getInitiativeDie();
+        const initFormula = initDie;
+        options.formula = initFormula;
+        return this.rollInitiative(ids, options);
+    }
+
+    async _getInitiativeDie() {
+        return await new Promise(async resolve => {
+            new Dialog({
+                title: game.i18n.localize("HM.dialog.initTitle"),
+                content: await renderTemplate("systems/hackmaster5e/templates/dialog/getinitdie.hbs"),
+                buttons: {
+                    getdie: {
+                        label: "Roll",
+                        callback: () => { resolve(document.getElementById("choices").value) }
+                    }
+                },
+                default:"getdie"
+            }).render(true);
+        });
+    }
 };
 
 export class HMCombatTracker extends CombatTracker {
@@ -66,26 +104,9 @@ export class HMCombatTracker extends CombatTracker {
 
         // Roll combatant initiative
         case "rollInitiative":
-            const initDie = await this._getInitiativeDie();
+            const initDie = await combat._getInitiativeDie();
             const initFormula = initDie;
-            console.warn(initDie);
             return combat.rollInitiative([c.id], {formula: initFormula});
         }
-    }
-
-    async _getInitiativeDie() {
-        return await new Promise(async resolve => {
-            new Dialog({
-                title: game.i18n.localize("HM.dialog.initTitle"),
-                content: await renderTemplate("systems/hackmaster5e/templates/dialog/getinitdie.hbs"),
-                buttons: {
-                    getdie: {
-                        label: "Roll",
-                        callback: () => { resolve(document.getElementById("choices").value) }
-                    }
-                },
-                default:"getdie"
-            }).render(true);
-        });
     }
 };

--- a/modules/sys/combat.js
+++ b/modules/sys/combat.js
@@ -32,7 +32,7 @@ export class HMCombat extends Combat {
          let cn = a.name.localeCompare(b.name);
          if ( cn !== 0 ) return cn;
          return a.id - b.id;
-   }
+    }
 };
 
 export class HMCombatTracker extends CombatTracker {
@@ -42,6 +42,50 @@ export class HMCombatTracker extends CombatTracker {
             template: "systems/hackmaster5e/templates/sidebar/combat-tracker.hbs",
             title: "Count Up",
             scrollY: [".directory-list"]
+        });
+    }
+
+    async _onCombatantControl(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const btn = event.currentTarget;
+        const li = btn.closest(".combatant");
+        const combat = this.viewed;
+        const c = combat.combatants.get(li.dataset.combatantId);
+
+        // Switch control action
+        switch (btn.dataset.control) {
+
+        // Toggle combatant visibility
+        case "toggleHidden":
+            return c.update({hidden: !c.hidden});
+
+        // Toggle combatant defeated flag
+        case "toggleDefeated":
+            return this._onToggleDefeatedStatus(c);
+
+        // Roll combatant initiative
+        case "rollInitiative":
+            const initDie = await this._getInitiativeDie();
+            const initFormula = initDie;
+            console.warn(initDie);
+            return combat.rollInitiative([c.id], {formula: initFormula});
+        }
+    }
+
+    async _getInitiativeDie() {
+        return await new Promise(async resolve => {
+            new Dialog({
+                title: game.i18n.localize("HM.dialog.initTitle"),
+                content: await renderTemplate("systems/hackmaster5e/templates/dialog/getinitdie.hbs"),
+                buttons: {
+                    getdie: {
+                        label: "Roll",
+                        callback: () => { resolve(document.getElementById("choices").value) }
+                    }
+                },
+                default:"getdie"
+            }).render(true);
         });
     }
 };

--- a/modules/sys/localize.js
+++ b/modules/sys/localize.js
@@ -61,6 +61,16 @@ idx.saves = {
     "top":      "HM.saves.top"
 }
 
+// Dialog
+idx.dice = {
+    "1d20":      "d20",
+    "1d12":      "d12",
+    "1d10":      "d10",
+    "1d8":       "d8",
+    "1d6":       "d6",
+    "1d4":       "d4"
+}
+
 // Images
 idx.savesImg = {
     "dodge":    "icons/skills/movement/feet-winged-boots-brown.webp",

--- a/modules/sys/partials.js
+++ b/modules/sys/partials.js
@@ -22,6 +22,7 @@ export default function preloadHandlebarsTemplates() {
         "systems/hackmaster5e/templates/actor/parts/skills.hbs",
         "systems/hackmaster5e/templates/item/parts/header-logistics.hbs",
         "systems/hackmaster5e/templates/item/parts/logistics.hbs",
-        "systems/hackmaster5e/templates/sidebar/combat-tracker.hbs"
+        "systems/hackmaster5e/templates/sidebar/combat-tracker.hbs",
+        "systems/hackmaster5e/templates/dialog/getinitdie.hbs"
     ]);
 }

--- a/templates/dialog/getinitdie.hbs
+++ b/templates/dialog/getinitdie.hbs
@@ -1,0 +1,6 @@
+<p>{{localize "HM.dialog.initBody"}}</p>
+<select name="data.quality" id="choices">
+    {{#select data.data.initdie}}{{#each (findConfigObj "dice") as |type t|}}
+        <option value="{{t}}">{{type}}</option>
+    {{/each}}{{/select}}
+</select>


### PR DESCRIPTION
Combat and CombatTracker now requests an init die from a player or GM when rolling for individual characters, all npcs, or all combatants.