### PR TITLE
combat tracker refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The roll20 system offers some features I won't get to in 0.1.x, and this will be
 - **The League of Extraordinary FoundryVTT Developers** for their unending patience and assistance.
 - **asacolips** for his excellent Boilerplate system, which provided the initial bones for this one.
 - **[Derg](https://github.com/derg4)** for providing penetration dice code.
+- Uses code adapted from **[Initiative Double Click](https://github.com/League-of-Foundry-Developers/fvtt-initiative-double-click)**
 - Kenzer and Company for granting me permission to undertake this project.
 
 #### Legal

--- a/hm.js
+++ b/hm.js
@@ -43,12 +43,7 @@ Hooks.once("ready", async() => {
     }
 });
 
-Hooks.on('renderCombatTracker', (chat, html, user) => {
-    if (!html.find("[data-control='nextTurn']").length) return;
-    html.find("[data-control='nextTurn']")[0].remove();
-    html.find("[data-control='previousTurn']")[0].remove();
-    html.find(".active").removeClass("active");
-});
+Hooks.on('renderCombatTracker', HMCombatTracker.renderCombatTracker);
 
 Hooks.on("diceSoNiceRollStart", (messageId, context) => {
     // Add 1 to penetration dice so dsn shows actual die throws.

--- a/hm.js
+++ b/hm.js
@@ -35,10 +35,11 @@ Hooks.once("init", async() => {
 Hooks.once("ready", async() => {
     // render a sheet to the screen as soon as we enter, for testing purposes.
     if (game.items.contents[0]) {
-    //    game.items.contents[0].sheet.render(true);
+     //   game.items.contents.find((a) => a.type === 'cclass').sheet.render(true);
     }
     if (game.actors.contents[0]) {
-        game.actors.contents[0].sheet.render(true);
+    //  game.actors.contents[0].sheet.render(true);
+//        game.actors.contents[0].items.find((a) => a.type === "cclass").sheet.render(true);
     }
 });
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -99,8 +99,8 @@
             "getDefendTitle":    ": Defend Thyself",
             "getSaveTitle":      "Save",
             "getSkillTitle":     " Skill Check",
-            "setinitTitle":      "Set Initiative",
-            "setinitBody":       "Enter a new initiative.",
+            "setInitTitle":      "Set Initiative",
+            "setInitBody":       "New Init",
             "setWoundTitle":     "Inflict Wound",
             "setWoundBody":      "Wound HP",
             "warnMulti":         "Multiple tokens selected. Using <b>"

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,8 +90,8 @@
         },
 
         "dialog": {
-            "initTitle":         "Choose an Initiative Die",
-            "initBody":          "Please select the appropriate initiative die.",
+            "getInitDieTitle":   "Roll for Initiative",
+            "getInitDieBody":    "Initiative Die",
             "getAttackTitle":    ": Roll an Attack",
             "getAbilityButtonL": "Ability Save",
             "getAbilityButtonR": "Ability Check",

--- a/modules/item/item-sheet.js
+++ b/modules/item/item-sheet.js
@@ -10,7 +10,7 @@ export class HackmasterItemSheet extends ItemSheet {
       classes: ["hackmaster", "sheet", "item"],
       width: 520,
       height: 480,
-      tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "config" }]
+      tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "attributes" }]
     });
   }
 

--- a/modules/mgr/dialogmgr.js
+++ b/modules/mgr/dialogmgr.js
@@ -1,13 +1,15 @@
 export default class HMDialogMgr {
     getDialog(dataset, caller=null) {
         const name = dataset.dialog;
-        if (name === 'atk')      { return this.getAttackDialog(dataset, caller)  } else
-        if (name === 'dmg')      { return this.getDamageDialog(dataset, caller)  } else
-        if (name === 'def')      { return this.getDefendDialog(dataset, caller)  } else
-        if (name === 'skill')    { return this.getSkillDialog(dataset, caller)   } else
-        if (name === 'ability')  { return this.getAbilityDialog(dataset, caller) } else
-        if (name === 'save')     { return this.getSaveDialog(dataset, caller)    } else
-        if (name === 'wound')    { return this.setWoundDialog(caller)            }
+        if (name === 'ability') { return this.getAbilityDialog(dataset, caller) } else
+        if (name === 'atk')     { return this.getAttackDialog(dataset, caller)  } else
+        if (name === 'def')     { return this.getDefendDialog(dataset, caller)  } else
+        if (name === 'dmg')     { return this.getDamageDialog(dataset, caller)  } else
+        if (name === 'setinit') { return this.setInitDialog(caller)             } else
+        if (name === 'initdie') { return this.getInitDieDialog(caller)          } else
+        if (name === 'save')    { return this.getSaveDialog(dataset, caller)    } else
+        if (name === 'skill')   { return this.getSkillDialog(dataset, caller)   } else
+        if (name === 'wound')   { return this.setWoundDialog(caller)            }
     }
 
     _focusById(id) {
@@ -17,6 +19,51 @@ export default class HMDialogMgr {
     getWeapons(actor, itemId) {
         if (itemId) return [actor.items.get(itemId)];
         return actor.items.filter((a) => a.type === "weapon");
+    }
+
+    async setInitDialog(caller) {
+        const dialogResp = {caller};
+
+        const template = "systems/hackmaster5e/templates/dialog/setInit.hbs";
+        dialogResp.resp = await new Promise(async resolve => {
+            new Dialog({
+                title: game.i18n.localize("HM.dialog.setInitTitle"),
+                content: await renderTemplate(template),
+                buttons: {
+                    setinit: {
+                        label: "Set Init",
+                        callback: () => {resolve({
+                            "value": document.getElementById("choices").value
+                        })}
+                    }
+                },
+                default:"setinit",
+                render: () => { document.getElementById("choices").focus() }
+            }, {width: 200}).render(true);
+        });
+        return dialogResp;
+    }
+
+    async getInitDieDialog(caller) {
+        const dialogResp = {caller};
+
+        const template = "systems/hackmaster5e/templates/dialog/getInitDie.hbs";
+        dialogResp.resp = await new Promise(async resolve => {
+            new Dialog({
+                title: game.i18n.localize("HM.dialog.getInitDieTitle"),
+                content: await renderTemplate(template),
+                buttons: {
+                    getdie: {
+                        label: "Roll",
+                        callback: () => {resolve({
+                            "die": document.getElementById("choices").value
+                        })}
+                    }
+                },
+                default:"getdie"
+            }, {width: 300}).render(true);
+        });
+        return dialogResp;
     }
 
     async setWoundDialog(caller) {

--- a/modules/sys/combat.js
+++ b/modules/sys/combat.js
@@ -29,8 +29,8 @@ export class HMCombat extends Combat {
     async _getInitiativeDie() {
         return await new Promise(async resolve => {
             new Dialog({
-                title: game.i18n.localize("HM.dialog.initTitle"),
-                content: await renderTemplate("systems/hackmaster5e/templates/dialog/getinitdie.hbs"),
+                title: game.i18n.localize("HM.dialog.getInitDieTitle"),
+                content: await renderTemplate("systems/hackmaster5e/templates/dialog/getInitDie.hbs"),
                 buttons: {
                     getdie: {
                         label: "Roll",
@@ -38,7 +38,7 @@ export class HMCombat extends Combat {
                     }
                 },
                 default:"getdie"
-            }).render(true);
+            }, {width: 300}).render(true);
         });
     }
 

--- a/modules/sys/partials.js
+++ b/modules/sys/partials.js
@@ -36,7 +36,7 @@ export default function preloadHandlebarsTemplates() {
         "systems/hackmaster5e/templates/dialog/getDefend.hbs",
         "systems/hackmaster5e/templates/dialog/getSave.hbs",
         "systems/hackmaster5e/templates/dialog/getSkill.hbs",
-        "systems/hackmaster5e/templates/dialog/getinitdie.hbs",
+        "systems/hackmaster5e/templates/dialog/getInitDie.hbs",
         "systems/hackmaster5e/templates/dialog/setWound.hbs",
         "systems/hackmaster5e/templates/dialog/setinit.hbs"
     ]);

--- a/modules/sys/partials.js
+++ b/modules/sys/partials.js
@@ -36,8 +36,8 @@ export default function preloadHandlebarsTemplates() {
         "systems/hackmaster5e/templates/dialog/getDefend.hbs",
         "systems/hackmaster5e/templates/dialog/getSave.hbs",
         "systems/hackmaster5e/templates/dialog/getSkill.hbs",
+        "systems/hackmaster5e/templates/dialog/setInit.hbs",
         "systems/hackmaster5e/templates/dialog/getInitDie.hbs",
-        "systems/hackmaster5e/templates/dialog/setWound.hbs",
-        "systems/hackmaster5e/templates/dialog/setinit.hbs"
+        "systems/hackmaster5e/templates/dialog/setWound.hbs"
     ]);
 }

--- a/scss/hackmaster.scss
+++ b/scss/hackmaster.scss
@@ -11,12 +11,17 @@
 
 /* Styles limited to hackmaster sheets */
 .hackmaster {
-  @import 'parts/forms';
-  @import 'parts/resource';
-  @import 'parts/tabs';
-  @import 'parts/skills';
-  @import 'parts/cards';
-  @import 'layout/actor-sheet';
-  @import 'cards/combat';
-  @import 'cards/inventory';
+    @import 'parts/forms';
+    @import 'parts/resource';
+    @import 'parts/tabs';
+    @import 'parts/skills';
+    @import 'parts/cards';
+    @import 'layout/actor-sheet';
+    @import 'cards/combat';
+    @import 'cards/inventory';
+}
+
+/* Styles which override foundry core */
+#combat {
+    @import 'overrides/combat';
 }

--- a/scss/helpers/_colors.scss
+++ b/scss/helpers/_colors.scss
@@ -1,2 +1,3 @@
 $c-white: #fff;
 $c-black: #000;
+$c-orange: #ff6400;

--- a/scss/overrides/_combat.scss
+++ b/scss/overrides/_combat.scss
@@ -1,0 +1,6 @@
+.initiative {
+    &:hover {
+        border: 1px solid $c-orange;
+        border-radius: 2px;
+    }
+}

--- a/styles/hackmaster.css
+++ b/styles/hackmaster.css
@@ -514,3 +514,9 @@
   grid-template-columns: 1fr 5em 5em;
   column-gap: 2em;
 }
+
+/* Styles which override foundry core */
+#combat .initiative:hover {
+  border: 1px solid #ff6400;
+  border-radius: 2px;
+}

--- a/templates/dialog/getInitDie.hbs
+++ b/templates/dialog/getInitDie.hbs
@@ -1,0 +1,10 @@
+<form>
+    <div class="form-group">
+        <label>{{localize "HM.dialog.getInitDieBody"}}</label>
+        <select name="data.quality" id="choices">
+            {{#select "1d12"}}{{#each (findConfigObj "dice") as |type t|}}
+            <option value="{{t}}">{{type}}</option>
+            {{/each}}{{/select}}
+        </select>
+    </div>
+</form>

--- a/templates/dialog/getinitdie.hbs
+++ b/templates/dialog/getinitdie.hbs
@@ -1,6 +1,0 @@
-<p>{{localize "HM.dialog.initBody"}}</p>
-<select name="data.quality" id="choices">
-    {{#select data.data.initdie}}{{#each (findConfigObj "dice") as |type t|}}
-        <option value="{{t}}">{{type}}</option>
-    {{/each}}{{/select}}
-</select>

--- a/templates/dialog/setInit.hbs
+++ b/templates/dialog/setInit.hbs
@@ -1,0 +1,6 @@
+<form>
+    <div class="form-group">
+        <label>{{localize "HM.dialog.setInitBody"}}</label>
+        <input id="choices" type="number"/>
+    </div>
+</form>

--- a/templates/dialog/setinit.hbs
+++ b/templates/dialog/setinit.hbs
@@ -1,3 +1,0 @@
-<p>{{localize "HM.dialog.setinitBody"}}</p>
-    <input id="choices" size="3em" type="number"/>
-</select>


### PR DESCRIPTION
Combat tracker has been redone. I've tidied up a lot of the underlying code here, and have replaced the 'Set Initiative' rmb context option with the ability to doubleclick the init for any combatant under game.user's control and edit it directly. This should be far more intuitive, provided the ui hint (border on hover) is sufficient to communicate this.