### PR TITLE
widened toggleswitch search range

### DIFF
--- a/modules/actor/actor-sheet.js
+++ b/modules/actor/actor-sheet.js
@@ -9,7 +9,7 @@ export class HMActorSheet extends ActorSheet {
         super.activateListeners(html);
 
         // ui elements
-        html.find('.toggle').click(this._onToggle.bind(this));
+        html.find('.toggleswitch').click(this._onToggle.bind(this));
 
         if (!this.options.editable) return;
         // ----------------------------------------------------- //
@@ -36,13 +36,9 @@ export class HMActorSheet extends ActorSheet {
         html.find('.item-state').click(this._onItemState.bind(this));
         html.find('.spell-state').click(this._onSpellState.bind(this));
 
-        // Rollable abilities.
+        // Interactables
         html.find('.button').click(this._onClick.bind(this));
         html.find('.rollable').click(this._onRoll.bind(this));
-
-        // HACK: Toggle is overly greedy. This sort of fixes it, but barely.
-        html.find('.editable').click(ev => ev.stopPropagation());
-        html.find('.editable').select(ev => ev.stopPropagation());
         html.find('.editable').change(this._onEdit.bind(this));
 
         // Drag events for macros.
@@ -91,11 +87,8 @@ export class HMActorSheet extends ActorSheet {
     async _onToggle(ev) {
         ev.preventDefault();
         const element = ev.currentTarget;
-        const id      = this._getItemId(ev);
-        const target  = $(element).find("[data-toggle='" + id + "']");
-        for (let i = 0; i < target.length; i++) {
-            $(target[i]).toggleClass("hide");
-        }
+        const target  = $(element).parent().find("[toggle]");
+        $(target).toggleClass("hide");
     }
 
     // Toggle between an item being equipped, carried, or stored.

--- a/templates/actor/cards/armor.hbs
+++ b/templates/actor/cards/armor.hbs
@@ -1,13 +1,13 @@
-<li class="card toggle" data-item-id="{{_id}}">
-    <div class="lid">
-        <header data-item-id="{{_id}}">
+<li class="card">
+    <div class="lid toggleswitch">
+        <header>
             <label for="{{name}}">
                 <img src="{{img}}" title="{{name}}" height="48"/>
                 <h4 class="card-name">{{name}}</h4>
             </label>
         </header>
     </div>
-    <article class="hide" data-toggle="{{_id}}">
+    <article class="hide" toggle>
         <div class="details">
             <div></div>
             <div class="stats">

--- a/templates/actor/cards/skill.hbs
+++ b/templates/actor/cards/skill.hbs
@@ -1,5 +1,5 @@
-<li class="toggle card hmstyle" data-item-id="{{_id}}">
-    <div class="lid">
+<li class="card hmstyle" data-item-id="{{_id}}">
+    <div class="lid toggleswitch">
         <header>
             <label for="{{name}}">
                 <div class="item-image"><img src="{{img}}" title="{{name}}" width="24" height="24"/></div>
@@ -11,7 +11,7 @@
                 </h4>
             </label>
         </header>
-        <section data-toggle="{{_id}}">
+        <section toggle>
             <div class="rollable button"
                 data-dialog="skill"
                 data-formula="1d100 + @resp.mod @resp.oper @mastery.derived.value"
@@ -20,7 +20,7 @@
             </div>
         </section>
     </div>
-    <article class="hide" data-toggle="{{_id}}">
+    <article class="hide" toggle>
         <div class="form-group">
             <label>{{localize "HM.mastery"}}:</label>
             <input class="editable" type="number" value="{{data.mastery.value}}"

--- a/templates/actor/cards/weapon.hbs
+++ b/templates/actor/cards/weapon.hbs
@@ -1,6 +1,6 @@
-<li class="card toggle" data-item-id="{{_id}}">
-    <div class="lid">
-        <header data-item-id="{{_id}}">
+<li class="card">
+    <div class="lid toggleswitch">
+        <header>
             <label for="{{name}}">
                 <img src="{{img}}" title="{{name}}" height="48"/>
                 <h4 class="card-name">{{name}}</h4>
@@ -21,7 +21,7 @@
                 data-item-id="{{_id}}">
         </section>
     </div>
-    <article class="hide" data-toggle="{{_id}}">
+    <article class="hide" toggle>
         <div class="details">
             <div class="stats">
                 <div></div>


### PR DESCRIPTION
Straightened out toggles so they finally behave as they should. No more weird behavior in the margins and such. Current drawback: Editing anything causes the sheet classes to reset. This issue still isn't resolved to satisfaction, but it's certainly a step in the right direction.