### PR TITLE
minor bugfixes

### DIFF
--- a/modules/actor/actor.js
+++ b/modules/actor/actor.js
@@ -3,11 +3,18 @@ import { HMTABLES } from '../sys/constants.js';
 export class HMActor extends Actor {
     prepareBaseData() {
         super.prepareBaseData();
+        this.resetBonus();
     }
 
     prepareDerivedData() {
         super.prepareDerivedData();
         this.setHP();
+    }
+
+    resetBonus() {
+        const {data} = this.data;
+        const {misc} = data.bonus;
+        data.bonus   = {'total': {}, misc};
     }
 
     async setRace() {
@@ -82,16 +89,9 @@ export class HMActor extends Actor {
     }
 
     get drObj() {
-        let armor  = this.data.data.bonus.total?.dr || 0;
-        let shield = 0;
-        const defItems = this.items.filter((a) => a.type === 'armor'
-                                               && a.data.data.state.equipped);
-
-        for (let i = 0; i < defItems.length; i++) {
-            const defData = defItems[i].data.data;
-            defData.shield.checked ? shield += defData.bonus.total.dr
-                                   : armor  += defData.bonus.total.dr;
-        }
+        const {bonus} = this.data.data;
+        const shield  = bonus.shield?.dr || 0;
+        const armor   = (bonus.total?.dr || 0) - shield;
         return {armor, shield};
     }
 

--- a/modules/actor/beast-actor.js
+++ b/modules/actor/beast-actor.js
@@ -9,6 +9,7 @@ export class HMBeastActor extends HMActor {
 
     prepareDerivedData() {
         super.prepareDerivedData();
+        this.setBonusTotal();
         this.setHP();
     }
 

--- a/modules/actor/character-actor.js
+++ b/modules/actor/character-actor.js
@@ -13,6 +13,7 @@ export class HMCharacterActor extends HMActor {
 
     prepareDerivedData() {
         super.prepareDerivedData();
+        this.setBonusTotal();
         this.setExtras();
         this.setEncumbrance();
     }

--- a/modules/item/item-sheet.js
+++ b/modules/item/item-sheet.js
@@ -49,7 +49,6 @@ export class HMItemSheet extends ItemSheet {
         if (!this.options.editable) return;
 
         html.find('.editable').change(this._onEdit.bind(this));
-        html.find('.dropdown').change(this._onChangeDropdown.bind(this));
     }
 
     async _onEdit(ev) {
@@ -68,21 +67,5 @@ export class HMItemSheet extends ItemSheet {
             await this.item.update({data:item.data.data});
             this.render(true);
         }
-    }
-
-    _onChangeDropdown(ev) {
-        ev.preventDefault();
-        const element = ev.currentTarget;
-        const dataset = element.dataset;
-
-        const ref1    = dataset.ref1;
-        const ref2    = $(element).val();
-        const ref3    = dataset.ref3;
-        if (ref2 === '0') { return; }
-
-        const key     = dataset.key;
-        const value   = HMTABLES[ref1][ref2][ref3];
-        const data    = {[key]: value};
-        return this.item.update(data);
     }
 }

--- a/modules/item/item.js
+++ b/modules/item/item.js
@@ -16,6 +16,7 @@ export class HMItem extends Item {
 
         if (type === 'armor')       { this._prepArmorData(options);               } else
         if (type === 'cclass')      { this._prepCClassData(data, actorData);      } else
+        if (type === 'race')        { this._prepRace();                           } else
         if (type === 'proficiency') { this._prepProficiencyData(data, actorData); }
     }
 
@@ -34,6 +35,17 @@ export class HMItem extends Item {
         const values = HMTABLES.quality[qKey].map((a) => a * qn);
         const keys = Object.keys(bonus.total);
         return Object.fromEntries(keys.map((_, i) => [keys[i], values[i]]));
+    }
+
+    _prepRace() {
+        const {data} = this.data;
+        const {bonus, scale} = data;
+
+        const scaleTable = HMTABLES.scale;
+        Object.keys(scale).forEach((key) => {
+            const idx = data.scale[key];
+            if (idx > 0) { bonus[key] = scaleTable[idx][key]; }
+        });
     }
 
     _prepArmorData({setBonus=true}={}) {

--- a/modules/sys/constants.js
+++ b/modules/sys/constants.js
@@ -232,15 +232,15 @@ export const HMTABLES = {
         'trauma':   { formula: '1d20  - @bonus.total.trauma    - @resp.bonus' },
         'turning':  { formula: '1d20p + @bonus.total.turning   + @resp.bonus' },
     },
-    "scale": {
-        1: {"hp":  0, "kb":  5, "reach": -2,  "movecf":  0.33},
-        2: {"hp":  5, "kb": 10, "reach": -1,  "movecf":  0.50},
-        3: {"hp": 10, "kb": 15, "reach":  0,  "movecf":  1.00},
-        4: {"hp": 15, "kb": 20, "reach":  1,  "movecf":  2.00},
-        5: {"hp": 20, "kb": 25, "reach":  2,  "movecf":  3.00},
-        6: {"hp": 25, "kb": 30, "reach":  3,  "movecf":  4.00},
-        7: {"hp": 35, "kb": 40, "reach":  5,  "movecf":  6.00},
-        8: {"hp": 70, "kb": 75, "reach":  12, "movecf": 13.00},
+    'scale': {
+        1: {'hp':  0, 'kb':  5, 'reach': -2,  'movecf':  0.33},
+        2: {'hp':  5, 'kb': 10, 'reach': -1,  'movecf':  0.50},
+        3: {'hp': 10, 'kb': 15, 'reach':  0,  'movecf':  1.00},
+        4: {'hp': 15, 'kb': 20, 'reach':  1,  'movecf':  2.00},
+        5: {'hp': 20, 'kb': 25, 'reach':  2,  'movecf':  3.00},
+        6: {'hp': 25, 'kb': 30, 'reach':  3,  'movecf':  4.00},
+        7: {'hp': 35, 'kb': 40, 'reach':  5,  'movecf':  6.00},
+        8: {'hp': 70, 'kb': 75, 'reach':  12, 'movecf': 13.00},
     },
     'skill': {
         '_pData': {

--- a/templates/item/item-race-sheet.hbs
+++ b/templates/item/item-race-sheet.hbs
@@ -19,10 +19,7 @@
                         <div class="options-row">
                             <label class="resource-label">{{localize "HM.hp"}}</label>
                             <span>
-                                <select class="dropdown" name="data.scale.hp"
-                                    data-ref1="scale"
-                                    data-ref3="hp"
-                                    data-key="data.bonus.hp"> 
+                                <select name="data.scale.hp">
                                 {{#select scale.hp}}{{#each (findConfigObj "scale") as |type t|}}
                                     <option value="{{t}}">{{localize type}}</option>
                                 {{/each}}{{/select}}
@@ -34,10 +31,7 @@
                         <div class="options-row">
                             <label class="resource-label">{{localize "HM.kb"}}</label>
                             <span>
-                                <select class="dropdown" name="data.scale.kb"
-                                    data-ref1="scale"
-                                    data-ref3="kb"
-                                    data-key="data.bonus.kb"> 
+                                <select name="data.scale.kb">
                                 {{#select scale.kb}}{{#each (findConfigObj "scale") as |type t|}}
                                     <option value="{{t}}">{{localize type}}</option>
                                 {{/each}}{{/select}}
@@ -49,10 +43,7 @@
                         <div class="options-row">
                             <label class="resource-label">{{localize "HM.reach"}}</label>
                             <span>
-                                <select class="dropdown" name="data.scale.reach"
-                                    data-ref1="scale"
-                                    data-ref3="reach"
-                                    data-key="data.bonus.reach"> 
+                                <select name="data.scale.reach">
                                 {{#select scale.reach}}{{#each (findConfigObj "scale") as |type t|}}
                                     <option value="{{t}}">{{localize type}}</option>
                                 {{/each}}{{/select}}


### PR DESCRIPTION
Armor and shields now contribute to character's bonus.total. While this makes accounting a lot easier (initiative is now tallied correctly), it means bonus.total is no longer the last say. For example, bonus.shield.dr should be considered when evaluating an actor's dr and in many cases the correct value to utilize is total.dr - shield.dr.

Also threw out old jquery code for race Items which weren't working correctly anyhow. This is replaced by a HMItem._racePrep() function to handle bookkeeping on the fly.